### PR TITLE
Streaming processing & simplify code.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use exitfailure::ExitFailure;
 use xd::*;
 
 fn main() -> Result<(), ExitFailure> {
-    // phare the argument and figure out the filename
+    // parse the argument and figure out the filename
     let opt = Opt::new();
     // println!("opt = {:#?}", opt);
 
@@ -10,13 +10,8 @@ fn main() -> Result<(), ExitFailure> {
     println!("File name : {:#?}", file_name);
 
     // get the content and print
-    let mut buf = vec![];
-    get_content(file_name, &mut buf)?;
-    match opt.get_color_option() {
-        true => print_hex_color(&buf, opt.get_length()),
-        false => print_hex(&buf, opt.get_length()),
-    }
-    
+    let reader = open_reader(file_name)?;
+    print_hex(reader, opt.get_length(), opt.get_color_option())?;
 
     Ok(())
 }


### PR DESCRIPTION
Make "print_hex" take an "impl Read" rather than a byte buffer to be able to read from a pipe like stdin.

```shell
$ xd /dev/stdin
hello world.
00000000     68 65 6c 6c 6f 20 77 6f  72 6c 64 0a                hello world.
0000000c
total length : 12 bytes
```